### PR TITLE
fixes a signed / unsigned int comparison

### DIFF
--- a/kolea.ino
+++ b/kolea.ino
@@ -36,7 +36,7 @@ char keys[ROWS][COLS] = {
 int rowPins[ROWS] = {4, 5, 6, 7};
 int colPins[COLS] = {8, 9, 10, 11, 12, 14, 15, 16, 18, 19, 20};
 int ledPin = 3;
-long debounceMillis = 20;
+unsigned long debounceMillis = 20;
 
 // Keyboard state variables
 boolean isStrokeInProgress = false;


### PR DESCRIPTION
initializes debounceMillis as an unsigned long (previously a signed long) to prevent the comparison conflict that arises on line 131 with debouncingMicros[i][j] which is an unsigned long